### PR TITLE
Fix Readme React hook example code typo (prop name)

### DIFF
--- a/packages/react-cookie/README.md
+++ b/packages/react-cookie/README.md
@@ -176,7 +176,7 @@ import { CookiesProvider } from 'react-cookie';
 
 export default function Root() {
   return (
-    <CookiesProvider defaultSetCookies={{ path: '/' }}>
+    <CookiesProvider defaultSetOptions={{ path: '/' }}>
       <App />
     </CookiesProvider>
   );


### PR DESCRIPTION
Hello,

While using this lib in react project, I copy&pasted the sample code from section `Simple Example with React hooks` in ReadMe.md.

I looked up the exported types and spotted a missing mismatching prop name. (`defaultSetCookies` is not a property of `CookiesProvider`, did you mean `defaultSetOptions` ?)
Fixing it would help a lot of people avoid the type error when following the documentation.

Thank you for the project and taking time to review my pull request.