### PR TITLE
Support partitioned attribute to manage the phasing out of third-party cookies

### DIFF
--- a/packages/react-cookie/README.md
+++ b/packages/react-cookie/README.md
@@ -84,6 +84,7 @@ Set a cookie value
   - secure (boolean): Is only accessible through HTTPS?
   - httpOnly (boolean): Can only the server access the cookie? **Note: You cannot get or set httpOnly cookies from the browser, only the server.**
   - sameSite (boolean|none|lax|strict): Strict or Lax enforcement
+  - partitioned (boolean): Indicates that the cookie should be stored using partitioned storage
 
 ### `removeCookie(name, [options])`
 
@@ -98,6 +99,7 @@ Remove a cookie
   - secure (boolean): Is only accessible through HTTPS?
   - httpOnly (boolean): Can only the server access the cookie? **Note: You cannot get or set httpOnly cookies from the browser, only the server.**
   - sameSite (boolean|none|lax|strict): Strict or Lax enforcement
+  - partitioned (boolean): Indicates that the cookie should be stored using partitioned storage
 
 ### `updateCookies()`
 
@@ -151,6 +153,7 @@ Set a cookie value
   - secure (boolean): Is only accessible through HTTPS?
   - httpOnly (boolean): Can only the server access the cookie? **Note: You cannot get or set httpOnly cookies from the browser, only the server.**
   - sameSite (boolean|none|lax|strict): Strict or Lax enforcement
+  - partitioned (boolean): Indicates that the cookie should be stored using partitioned storage
 
 ### `remove(name, [options])`
 
@@ -165,6 +168,7 @@ Remove a cookie
   - secure (boolean): Is only accessible through HTTPS?
   - httpOnly (boolean): Can only the server access the cookie? **Note: You cannot get or set httpOnly cookies from the browser, only the server.**
   - sameSite (boolean|none|lax|strict): Strict or Lax enforcement
+  - partitioned (boolean): Indicates that the cookie should be stored using partitioned storage
 
 ## Simple Example with React hooks
 

--- a/packages/universal-cookie/README.md
+++ b/packages/universal-cookie/README.md
@@ -41,6 +41,7 @@ Create a cookies context
   - secure (boolean): Is only accessible through HTTPS?
   - httpOnly (boolean): Is only the server can access the cookie? **Note: You cannot get or set httpOnly cookies from the browser, only the server.**
   - sameSite (boolean|none|lax|strict): Strict or Lax enforcement
+  - partitioned (boolean): Indicates that the cookie should be stored using partitioned storage
 
 ### `get(name, [options])`
 
@@ -71,6 +72,7 @@ Set a cookie value
   - secure (boolean): Is only accessible through HTTPS?
   - httpOnly (boolean): Is only the server can access the cookie? **Note: You cannot get or set httpOnly cookies from the browser, only the server.**
   - sameSite (boolean|none|lax|strict): Strict or Lax enforcement
+  - partitioned (boolean): Indicates that the cookie should be stored using partitioned storage
 
 ### `remove(name, [options])`
 
@@ -85,6 +87,7 @@ Remove a cookie
   - secure (boolean): Is only accessible through HTTPS?
   - httpOnly (boolean): Is only the server can access the cookie? **Note: You cannot get or set httpOnly cookies from the browser, only the server.**
   - sameSite (boolean|none|lax|strict): Strict or Lax enforcement
+  - partitioned (boolean): Indicates that the cookie should be stored using partitioned storage
 
 ### `addChangeListener(callback)`
 

--- a/packages/universal-cookie/src/types.ts
+++ b/packages/universal-cookie/src/types.ts
@@ -13,6 +13,7 @@ export interface CookieSetOptions {
   secure?: boolean;
   httpOnly?: boolean;
   sameSite?: boolean | 'none' | 'lax' | 'strict';
+  partitioned?: boolean;
 }
 export interface CookieChangeOptions {
   name: string;


### PR DESCRIPTION
Chrome plans to gradually phase out support for third-party cookies (3PC), starting January 4th, 2024. Initially, this will involve disabling third-party cookies for 1% of users to enable testing.

To address the deprecation of third-party cookies, one approach is using [CHIPS (Cookies Having Independent Partitioned State)](https://developers.google.com/privacy-sandbox/3pcd/chips)

CHIPS enhances user privacy and security with a novel approach. It introduces a `Partitioned` attribute for cookies, enabling developers to opt for partitioned storage. This creates separate cookie jars for each top-level site.