### PR TITLE
refactor(universal-cookies): replace “cookie” with “cookie-es”

### DIFF
--- a/packages/universal-cookie/package.json
+++ b/packages/universal-cookie/package.json
@@ -43,8 +43,7 @@
     "build": "rollup -c"
   },
   "dependencies": {
-    "@types/cookie": "^0.6.0",
-    "cookie": "^0.6.0"
+    "cookie-es": "^1.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.23.9",

--- a/packages/universal-cookie/src/Cookies.ts
+++ b/packages/universal-cookie/src/Cookies.ts
@@ -1,4 +1,4 @@
-import * as cookie from 'cookie';
+import { parse, serialize } from 'cookie-es';
 import {
   Cookie,
   CookieChangeListener,
@@ -99,7 +99,7 @@ export default class Cookies {
     this.cookies = { ...this.cookies, [name]: stringValue };
 
     if (this.HAS_DOCUMENT_COOKIE) {
-      document.cookie = cookie.serialize(name, stringValue, options);
+      document.cookie = serialize(name, stringValue, options);
     }
 
     this._emitChange({ name, value, options });
@@ -117,7 +117,7 @@ export default class Cookies {
     delete this.cookies[name];
 
     if (this.HAS_DOCUMENT_COOKIE) {
-      document.cookie = cookie.serialize(name, '', finalOptions);
+      document.cookie = serialize(name, '', finalOptions);
     }
 
     this._emitChange({ name, value: undefined, options });
@@ -129,7 +129,7 @@ export default class Cookies {
     }
 
     const previousCookies = this.cookies;
-    this.cookies = cookie.parse(document.cookie);
+    this.cookies = parse(document.cookie);
     this._checkChanges(previousCookies);
   };
 

--- a/packages/universal-cookie/src/utils.ts
+++ b/packages/universal-cookie/src/utils.ts
@@ -1,4 +1,4 @@
-import * as cookie from 'cookie';
+import { parse } from 'cookie-es';
 import { Cookie, CookieGetOptions } from './types';
 
 export function hasDocumentCookie() {
@@ -25,7 +25,7 @@ export function cleanCookies() {
 
 export function parseCookies(cookies?: string | object | null) {
   if (typeof cookies === 'string') {
-    return cookie.parse(cookies);
+    return parse(cookies);
   } else if (typeof cookies === 'object' && cookies !== null) {
     return cookies;
   } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1823,11 +1823,6 @@
   dependencies:
     "@babel/types" "^7.20.7"
 
-"@types/cookie@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.6.0.tgz#eac397f28bf1d6ae0ae081363eca2f425bedf0d5"
-  integrity sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==
-
 "@types/eslint-scope@^3.7.3":
   version "3.7.7"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.7.tgz#3108bd5f18b0cdb277c867b3dd449c9ed7079ac5"
@@ -2731,6 +2726,11 @@ convert-source-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
+cookie-es@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/cookie-es/-/cookie-es-1.0.0.tgz#4759684af168dfc54365b2c2dda0a8d7ee1e4865"
+  integrity sha512-mWYvfOLrfEc996hlKcdABeIiPHUPC6DM2QYZdGGOvhOTbA3tjm2eBwqlJpoFdjC89NI4Qt6h0Pu06Mp+1Pj5OQ==
+
 cookie-signature@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
@@ -2740,11 +2740,6 @@ cookie@0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
-
-cookie@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.6.0.tgz#2798b04b071b0ecbff0dbb62a505a8efa4e19051"
-  integrity sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==
 
 core-js-compat@^3.31.0:
   version "3.35.0"


### PR DESCRIPTION
With [`cookie-es`](https://github.com/unjs/cookie-es/)  there is now a modern, typed drop-in replacement for the `cookie` package. This pull request simply replaces the dependency and removes the now obsolete `@types/cookie` dependency.

This solves an issue within VueUse’s [useCookies](https://vueuse.org/integrations/useCookies/) when used within [Nuxt](https://nuxt.com/).

As far as I am aware, this should be fully backwards compatible and should not introduce any breaking changes. The `cookie-es` package provides an export for `require`.

It’d be great if this change could be considered! Let me know of any thoughts and concerns.