### PR TITLE
fix: do not update during render

### DIFF
--- a/packages/react-cookie/src/useCookies.tsx
+++ b/packages/react-cookie/src/useCookies.tsx
@@ -16,7 +16,9 @@ export default function useCookies<T extends string, U = { [K in T]?: any }>(
     throw new Error('Missing <CookiesProvider>');
   }
 
-  const [allCookies, setCookies] = useState(() => cookies.getAll({ doNotUpdate: true }));
+  const [allCookies, setCookies] = useState(() =>
+    cookies.getAll({ doNotUpdate: true }),
+  );
 
   if (isInBrowser()) {
     useLayoutEffect(() => {

--- a/packages/react-cookie/src/useCookies.tsx
+++ b/packages/react-cookie/src/useCookies.tsx
@@ -16,7 +16,7 @@ export default function useCookies<T extends string, U = { [K in T]?: any }>(
     throw new Error('Missing <CookiesProvider>');
   }
 
-  const [allCookies, setCookies] = useState(() => cookies.getAll());
+  const [allCookies, setCookies] = useState(() => cookies.getAll({ doNotUpdate: true }));
 
   if (isInBrowser()) {
     useLayoutEffect(() => {

--- a/packages/react-cookie/src/withCookies.tsx
+++ b/packages/react-cookie/src/withCookies.tsx
@@ -48,7 +48,7 @@ export default function withCookies<T extends ReactCookieProps>(
 
     render() {
       const { forwardedRef, cookies, ...restProps } = this.props;
-      const allCookies = cookies.getAll();
+      const allCookies = cookies.getAll({ doNotUpdate: true });
       return (
         <WrappedComponent
           {...(restProps as T)}


### PR DESCRIPTION
I've noticed that, probably due to concurrent rendering in react 18, setState within useCookies is being called from within a render of another component:
- Component A calls useCookies()
- Component B calls useCookies([keyX])
- React complains, that component B sets the state of component A during render (as cookies.getAll() triggers listeners)

Our fix was to always pass the keys to useCookies, but since that might not always be an option, I think this should be the correct solution to the issue.