### PR TITLE
feat: add removeAllChangeListeners method

### DIFF
--- a/packages/universal-cookie/README.md
+++ b/packages/universal-cookie/README.md
@@ -99,6 +99,10 @@ Add a listener to when a cookie is set or removed.
 
 Remove a listener from the change callback.
 
+### `removeAllChangeListeners()`
+
+Remove all change listeners that were previously added with `addChangeListener()`.
+
 ### `update()`
 
 Read back the cookies from the browser and triggers the change listeners. This should normally not be necessary because this library detects cookie changes automatically.

--- a/packages/universal-cookie/src/Cookies.ts
+++ b/packages/universal-cookie/src/Cookies.ts
@@ -159,4 +159,10 @@ export default class Cookies {
       }
     }
   }
+
+  public removeAllChangeListeners() {
+    while (this.changeListeners.length > 0) {
+      this.removeChangeListener(this.changeListeners[0]);
+    }
+  }
 }

--- a/packages/universal-cookie/src/__tests__/Cookies-test.js
+++ b/packages/universal-cookie/src/__tests__/Cookies-test.js
@@ -247,5 +247,25 @@ describe('Cookies', () => {
       cookies.remove('test', 'boom!');
       expect(onChange).not.toHaveBeenCalled();
     });
+
+    it('removes all listeners at once', () => {
+      const cookies = new Cookies();
+
+      const onChange1 = jest.fn();
+      const onChange2 = jest.fn();
+      const onChange3 = jest.fn();
+
+      cookies.addChangeListener(onChange1);
+      cookies.addChangeListener(onChange2);
+      cookies.addChangeListener(onChange3);
+
+      cookies.removeAllChangeListeners();
+
+      cookies.set('test', 'value');
+
+      expect(onChange1).not.toHaveBeenCalled();
+      expect(onChange2).not.toHaveBeenCalled();
+      expect(onChange3).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Add the ability to remove all change listeners at once with a single method call
- Simplifies cleanup code in components that use cookie change listeners

## Test plan
- Added a comprehensive test to verify that all change listeners are properly removed
- Verified that the implementation correctly cleans up all related event handlers