### PR TITLE
fix: refactor useLayoutEffect to follow React Hook rules and update SSR tests

### DIFF
--- a/packages/react-cookie/src/__tests__/useCookies-server-test.js
+++ b/packages/react-cookie/src/__tests__/useCookies-server-test.js
@@ -38,7 +38,8 @@ describe('useCookies', () => {
 
     it('does not track changes', () => {
       const cookies = new Cookies('test="big fat cat"');
-      jest.spyOn(React, 'useLayoutEffect');
+
+      const addChangeListenerSpy = jest.spyOn(cookies, 'addChangeListener');
 
       ReactDOMServer.renderToString(
         <CookiesProvider cookies={cookies}>
@@ -46,7 +47,7 @@ describe('useCookies', () => {
         </CookiesProvider>,
       );
 
-      expect(React.useLayoutEffect).not.toHaveBeenCalled();
+      expect(addChangeListenerSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/react-cookie/src/useCookies.tsx
+++ b/packages/react-cookie/src/useCookies.tsx
@@ -1,4 +1,4 @@
-import { useContext, useLayoutEffect, useState, useRef, useMemo } from 'react';
+import { useContext, useLayoutEffect, useState, useMemo } from 'react';
 import { Cookie, CookieSetOptions, CookieGetOptions } from 'universal-cookie';
 import CookiesContext from './CookiesContext';
 import { isInBrowser } from './utils';
@@ -22,27 +22,29 @@ export default function useCookies<T extends string, U = { [K in T]?: any }>(
 
   const [allCookies, setCookies] = useState(() => cookies.getAll(getOptions));
 
-  if (isInBrowser()) {
-    useLayoutEffect(() => {
-      function onChange() {
-        if (!cookies) {
-          throw new Error('Missing <CookiesProvider>');
-        }
+  const isInBrowserEnv = isInBrowser();
 
-        const newCookies = cookies.getAll(getOptions);
+  useLayoutEffect(() => {
+    if (!isInBrowserEnv) return;
 
-        if (shouldUpdate(dependencies || null, newCookies, allCookies)) {
-          setCookies(newCookies);
-        }
+    function onChange() {
+      if (!cookies) {
+        throw new Error('Missing <CookiesProvider>');
       }
 
-      cookies.addChangeListener(onChange);
+      const newCookies = cookies.getAll(getOptions);
 
-      return () => {
-        cookies.removeChangeListener(onChange);
-      };
-    }, [cookies, allCookies]);
-  }
+      if (shouldUpdate(dependencies || null, newCookies, allCookies)) {
+        setCookies(newCookies);
+      }
+    }
+
+    cookies.addChangeListener(onChange);
+
+    return () => {
+      cookies.removeChangeListener(onChange);
+    };
+  }, [cookies, allCookies, isInBrowserEnv]);
 
   const setCookie = useMemo(() => cookies.set.bind(cookies), [cookies]);
   const removeCookie = useMemo(() => cookies.remove.bind(cookies), [cookies]);


### PR DESCRIPTION
**Summary:**  
Refactored `useLayoutEffect` to comply with React's Rules of Hooks and updated the corresponding SSR test.

**Changes:**  
- **Conditional Hook Fix**  
  Moved `isInBrowser()` inside `useLayoutEffect` to avoid conditional hook calls.  
- **SSR Optimization**  
  Introduced `isInBrowserEnv` for early exit on the server.  
- **Test Updates**  
  Replaced hook call assertion with a check ensuring `addChangeListener` is not called when `isInBrowser` returns `false`.

**Outcome:**  
- 🛠️ Ensures correct behavior in both browser and server environments.  
- ⚛️ Aligns with React best practices (no hook violations).  
- ✅ Maintains accurate and relevant test coverage.  